### PR TITLE
DO NOT MERGE - gemspec cleanup for rails42

### DIFF
--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -28,12 +28,9 @@ Gem::Specification.new do |s|
 
   #add gems here for files
   s.add_development_dependency 'dotenv'
-  s.add_development_dependency 'deface', '~> 1.0'
   s.add_development_dependency 'capybara', '~> 2.1'
-  s.add_development_dependency 'coffee-rails', '~> 4.0'
   s.add_development_dependency 'database_cleaner', '~> 1.2'
   s.add_development_dependency 'factory_girl', '~> 4.5'
-  s.add_development_dependency 'ffaker', '~> 1.23'
   s.add_development_dependency 'rspec-rails',  '~> 3.1'
   s.add_development_dependency 'rspec-its', '~> 1.0'
   s.add_development_dependency 'sass-rails', '~> 4.0'


### PR DESCRIPTION
This is a test PR

I will test this against the hw_admin rails 42 mega branch.

Why?

unable to bundle development deps.

bundler resolves Fullscript/spree to satisfy spree gem BUT it reaches out to rubygems for spree when resolving other deps

```

Bundler could not find compatible versions for gem "i18n": <===== THIS
  In Gemfile:
    rspec-rails (~> 3.1) was resolved to 3.1.0, which depends on
      actionpack (>= 3.0) was resolved to 4.2.9, which depends on
        activesupport (= 4.2.9) was resolved to 4.2.9, which depends on <=== yay!
          i18n (~> 0.7)

    spree was resolved to 2.2.13.beta, which depends on
      spree_core (= 2.2.13.beta) was resolved to 2.2.13.beta, which depends on
        i18n (= 0.6.9) <==== Booo!
```

This would not be an issue (I think) pulling spree_avatax_certified into hw_admin

but bundling for dev purposes is broken. This can be worked around on the local dev env.