### PR TITLE
Remove psych dependency

### DIFF
--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'rest-client', '~> 1.7'
-  s.add_dependency 'psych', '~> 2.0.4'
   s.add_dependency 'logging', '~> 1.8'
   s.add_dependency 'dalli', '~> 2.7'
 


### PR DESCRIPTION
This dep pins apps to 2.0.X of psych

In ruby 2.X.X land, psych is included in the distro

currently, 2.3.5 ships with psych 2.1.X